### PR TITLE
Create GitLeaks workflow in GitHub Actions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -47,6 +47,11 @@ jobs:
           options: -v ${{ github.WORKSPACE }}:/app
           run: |
             cd /app
-            gitleaks --verbose --additional-config='gitleaks.toml' \
-              --repo-url='${{ github.SERVER_URL }}/${{ github.REPOSITORY }}' \
-              --access-token='${{ secrets.GITHUB_TOKEN }}'
+            if [[ ${{ env.BRANCH }} == 'main' ]]; then
+              gitleaks --verbose --additional-config='gitleaks.toml' \
+                --repo-url='${{ github.SERVER_URL }}/${{ github.REPOSITORY }}' \
+                --access-token='${{ secrets.GITHUB_TOKEN }}'
+            else
+              gitleaks --verbose --additional-config='gitleaks.toml' \
+                --path='./' --commits='${{ env.COMMITS }}'
+            fi

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -47,11 +47,6 @@ jobs:
           options: -v ${{ github.WORKSPACE }}:/app
           run: |
             cd /app
-            if [[ ${{ env.BRANCH }} == 'main' ]]; then
-              gitleaks --verbose --additional-config='gitleaks.toml' \
-                --repo-url='${{ github.SERVER_URL }}/${{ github.REPOSITORY }}' \
-                --access-token='${{ secrets.GITHUB_TOKEN }}'
-            else
-              gitleaks --verbose --additional-config='gitleaks.toml' \
-                --path='./' --commits='${{ env.COMMITS }}'
-            fi
+            gitleaks --verbose --additional-config='gitleaks.toml' \
+              --repo-url='${{ github.SERVER_URL }}/${{ github.REPOSITORY }}' \
+              --access-token='${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,57 @@
+name: GitLeaks
+
+# Override desired times to run this workflow
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+# Override environment variables as needed
+env:
+  GITLEAKS_CONFIG_COMMITS: "[]" # A list of commits to ignore when running GitLeaks
+  GITLEAKS_CONFIG_REGEXES: "[]" # A list of regexes or secrets to ignore when running GitLeaks
+
+###########################################################
+### DO NOT EDIT BELOW – TEXT IS AUTOMATICALLY GENERATED ###
+###########################################################
+
+jobs:
+  default:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Branch Variable
+        run: |
+          if [[ ${{ github.REF }} == 'refs/heads'* ]]; then # this is a branch, not a pull request
+            echo "BRANCH=$(echo ${{ github.REF }} | sed -E 's|refs/[a-zA-Z]+/||')" >> $GITHUB_ENV
+          else
+            echo "BRANCH=$(echo ${{ github.HEAD_REF }} | sed -E 's|refs/[a-zA-Z]+/||')" >> $GITHUB_ENV
+          fi
+      - name: Check Out Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set GitLeaks Config
+        run: |
+          echo "COMMITS=$(
+            git rev-list origin/${{ env.BRANCH }} ^origin/main | sed 's/^\|$//g' | paste -sd, -
+          )" >> $GITHUB_ENV
+          echo "Title = 'GitLeaks Allowlist'" >> ${{ github.WORKSPACE }}/gitleaks.toml
+          echo "[allowlist]" >> ${{ github.WORKSPACE }}/gitleaks.toml
+          echo "  commits = ${{ env.GITLEAKS_CONFIG_COMMITS }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
+          echo "  regexes = ${{ env.GITLEAKS_CONFIG_REGEXES }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
+      - name: GitLeaks
+        uses: addnab/docker-run-action@v3
+        with:
+          image: zricethezav/gitleaks
+          options: -v ${{ github.WORKSPACE }}:/app
+          run: |
+            cd /app
+            if [[ ${{ env.BRANCH }} == 'main' ]]; then
+              gitleaks --verbose --additional-config='gitleaks.toml' \
+                --repo-url='${{ github.SERVER_URL }}/${{ github.REPOSITORY }}' \
+                --access-token='${{ secrets.GITHUB_TOKEN }}'
+            else
+              gitleaks --verbose --additional-config='gitleaks.toml' \
+                --path='./' --commits='${{ env.COMMITS }}'
+            fi

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -20,13 +20,6 @@ jobs:
   default:
     runs-on: ubuntu-latest
     steps:
-      - name: Set Branch Variable
-        run: |
-          if [[ ${{ github.REF }} == 'refs/heads'* ]]; then # this is a branch, not a pull request
-            echo "BRANCH=$(echo ${{ github.REF }} | sed -E 's|refs/[a-zA-Z]+/||')" >> $GITHUB_ENV
-          else
-            echo "BRANCH=$(echo ${{ github.HEAD_REF }} | sed -E 's|refs/[a-zA-Z]+/||')" >> $GITHUB_ENV
-          fi
       - name: Check Out Code
         uses: actions/checkout@v2
         with:
@@ -34,7 +27,7 @@ jobs:
       - name: Set GitLeaks Config
         run: |
           echo "COMMITS=$(
-            git rev-list origin/${{ env.BRANCH }} ^origin/main | sed 's/^\|$//g' | paste -sd, -
+            git rev-list ${{ github.SHA }} ^origin/main | sed 's/^\|$//g' | paste -sd, -
           )" >> $GITHUB_ENV
           echo "Title = 'GitLeaks Allowlist'" >> ${{ github.WORKSPACE }}/gitleaks.toml
           echo "[allowlist]" >> ${{ github.WORKSPACE }}/gitleaks.toml
@@ -47,7 +40,7 @@ jobs:
           options: -v ${{ github.WORKSPACE }}:/app
           run: |
             cd /app
-            if [[ ${{ env.BRANCH }} == 'main' ]]; then
+            if [[ ${{ github.REF }} == 'refs/heads/main' ]]; then
               gitleaks --verbose --additional-config='gitleaks.toml' \
                 --repo-url='${{ github.SERVER_URL }}/${{ github.REPOSITORY }}' \
                 --access-token='${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## Changes

Create a GitHub Actions workflow that runs [GitLeaks](https://github.com/zricethezav/gitleaks) on every commit to `main`, as well as each push to a pull request. If running on `main`, it scans all commits in the entire repository (except allowlisted commits/regexes/secrets). If running on a PR, then it scans only the commits between that PR and `main`.

This workflow was generated automatically from a private CI templates tool.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
